### PR TITLE
Update styling to match Leaflet 0.6 style

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -22,14 +22,19 @@
       var map = L.TileJSON.createMap('map', osmTileJSON);
 
       // You can turn it off and add it manually by using the option zoomSliderControl: false
-      // var map = L.TileJSON.createMap('map', osmTileJSON, { mapOptions: { zoomsliderControl: false }});
-      // map.addControl(new L.Control.Zoomslider());
+
+      //var map = L.TileJSON.createMap('map', osmTileJSON, { mapConfig: { zoomsliderControl: false }});
+      //map.addControl(new L.Control.Zoomslider());
+
+      // Add manually while passing a styleClass; 'simple' results in a slider bar without hashmarks (no background image)
+      //var map = L.TileJSON.createMap('map', osmTileJSON, { mapConfig: { zoomsliderControl: false }});
+      //map.addControl(new L.Control.Zoomslider({ styleClass: 'simple' }));
 
       // You can restore the original control by turning the zoomslider off and turning the zoomControl on 
-      //var map = L.TileJSON.createMap('map', osmTileJSON, { mapOptions: { zoomsliderControl: false, zoomControl: true }});
+      //var map = L.TileJSON.createMap('map', osmTileJSON, { mapConfig: { zoomsliderControl: false, zoomControl: true }});
 
       // Or turn them both on. 
-      //var map = L.TileJSON.createMap('map', osmTileJSON, { mapOptions: { zoomsliderControl: true, zoomControl: true }});
+      //var map = L.TileJSON.createMap('map', osmTileJSON, { mapConfig: { zoomsliderControl: true, zoomControl: true }});
       
     </script>
   </body>

--- a/src/L.Control.Zoomslider.css
+++ b/src/L.Control.Zoomslider.css
@@ -1,15 +1,24 @@
 /** Slider **/
 .leaflet-control-zoomslider-slider {
-	padding-top: 5px ;
+	padding-top: 5px;
 	padding-bottom: 5px;
+	background-color: #fff;
+	border-bottom: 1px solid #ccc;
 }
 
 .leaflet-control-zoomslider-slider-body {
 	background-image: url(images/zoom-slider.png);
 	background-repeat: repeat-y;
-	background-position: center 0px;
+	background-position: 47% 0px;
 	height: 100%;
 	cursor: default;
+}
+.leaflet-control-zoomslider-slider-body.leaflet-control-zoomslider-simple {
+	width: 1px;
+	border: 2px solid #999;
+	background-image: none;
+	background-color: #efefef;
+	margin: 0 auto;
 }
 
 .leaflet-control-zoomslider-slider-knob {
@@ -19,9 +28,17 @@
 	background-position: center;
  	-webkit-border-radius: 15px;
 	border-radius: 15px;
-	margin-left: 5px;
+	margin-left: 6px;
 	/*border: 5px; */
 	position:relative;
+}
+.leaflet-control-zoomslider-slider-body.leaflet-control-zoomslider-simple .leaflet-control-zoomslider-slider-knob {
+	height:4px;
+	background-color: #efefef;
+ 	-webkit-border-radius: 2px;
+	border-radius: 2px;
+	border: 2px solid #444;
+	margin-left: -8px;
 }
 
 .leaflet-control-zoomslider-slider-body:hover {
@@ -47,29 +64,28 @@
 
 /** Leaflet Zoom Styles **/
 .leaflet-container .leaflet-control-zoomslider {
-	margin-left: 13px;
-	margin-top: 12px;
+	margin-left: 10px;
+	margin-top: 10px;
 }
 .leaflet-control-zoomslider a {
-	width: 23px;
-	height: 22px;
+	width: 26px;
+	height: 26px;
 	text-align: center;
 	text-decoration: none;
 	color: black;
 	display: block;
 }
 .leaflet-control-zoomslider a:hover {
-	background-color: #fff;
-	color: #777;
+	background-color: #f4f4f4;
 }
 .leaflet-control-zoomslider-in {
-	font: bold 19px/24px Arial, Helvetica, sans-serif;
+	font: bold 18px 'Lucida Console', Monaco, monospace;
 }
 .leaflet-control-zoomslider-in:after{
 	content:"+"
 }
 .leaflet-control-zoomslider-out {
-	font: bold 23px/20px Tahoma, Verdana, sans-serif;
+	font: bold 22px 'Lucida Console', Monaco, monospace;
 }
 .leaflet-control-zoomslider-out:after{
 	content:"-"
@@ -81,8 +97,16 @@
 
 /* Touch */
 
+.leaflet-touch .leaflet-control-zoomslider-slider-body {
+	background-position: 10px 0px;
+}
 .leaflet-touch .leaflet-control-zoomslider-slider-knob {
-	width:20px;
+	width:19px;
+	margin-left: 5px;
+}
+.leaflet-touch .leaflet-control-zoomslider-slider-body.leaflet-control-zoomslider-simple .leaflet-control-zoomslider-slider-knob {
+	width:16px;
+	margin-left: -1px;
 }
 .leaflet-touch .leaflet-control-zoomslider a {
 	width: 30px;
@@ -94,7 +118,7 @@
 }
 .leaflet-touch .leaflet-control-zoomslider-out {
 	font-size: 28px;
-	line-height: 24px;
+	line-height: 30px;
 }
 
 .leaflet-touch .leaflet-control-zoomslider {

--- a/src/L.Control.Zoomslider.ie.css
+++ b/src/L.Control.Zoomslider.ie.css
@@ -1,9 +1,6 @@
 
-.leaflet-control-zoomslider a, .leaflet-control-zoomslider-slider {
-	background-color: #eee;
-}
-.leaflet-control-zoomslider a:hover {
-	background-color: #fff;
+.leaflet-control-zoomslider {
+  border: 3px solid #999;
 }
 .leaflet-control-zoomslider-slider {
 	padding-top: 4px;
@@ -13,7 +10,7 @@
 
 /* IE6-7 specific hacks */
 .leaflet-control-zoomslider-slider {
-	*width: 23px;
+	*width: 26px;
 }
 /* Fix IE6-divs having a too large min height  */
 .leaflet-control-zoomslider-slider-knob {

--- a/src/L.Control.Zoomslider.js
+++ b/src/L.Control.Zoomslider.js
@@ -60,7 +60,9 @@ L.Control.Zoomslider = (function () {
 			stepHeight: 9,
 			// Height of the knob div in px
 			knobHeight: 5,
-			styleNS: 'leaflet-control-zoomslider'
+			styleNS: 'leaflet-control-zoomslider',
+      //slider styleClass: set to 'simple' for slider bar without hashmarks (i.e. no background image)
+      styleClass: null
 		},
 
 		onAdd: function (map) {
@@ -112,9 +114,10 @@ L.Control.Zoomslider = (function () {
 		},
 
 		_createSlider: function () {
-			this._sliderBody = L.DomUtil.create('div',
-												this.options.styleNS + '-slider-body',
-												this._sliderElem);
+			var sliderStyleClass = !this.options.styleClass ? '' : ' ' + this.options.styleNS + '-' + this.options.styleClass;
+      this._sliderBody = L.DomUtil.create('div',
+                        this.options.styleNS + '-slider-body' + sliderStyleClass,
+                        this._sliderElem);
 			L.DomEvent.on(this._sliderBody, 'click', this._onSliderClick, this);
 		},
 


### PR DESCRIPTION
Includes CSS changes to make the zoomslider consistent in appearance with Leaflet's 0.6 style.

I've also added an option called styleClass that allows you to add the zoomslider control to a map with an additional style class to the .leaflet-control-zoomslider-slider-body element. The CSS includes styling for a simplified slider bar look (set styleClass to 'simple') that does not depend upon a background image. (It looks more like the Google slider but still consistent with Leaflet's overall style.) E.g.:

```
map.addControl(new L.Control.Zoomslider({ styleClass: 'simple' }));
```
