### PR TITLE
Check valid zoom levels before updating knob value (IE8 bug)

### DIFF
--- a/src/L.Control.Zoomslider.js
+++ b/src/L.Control.Zoomslider.js
@@ -174,7 +174,7 @@ L.Control.Zoomslider = (function () {
 			this._map.setZoom(this._toZoomLevel(this._knob.getValue()));
 		},
 		_updateKnob: function () {
-			if (this._knob) {
+			if (this._zoomLevels() < Infinity  && this._knob  && this._sliderBody) {
 				this._knob.setValue(this._toValue(this._map.getZoom()));
 			}
 		},


### PR DESCRIPTION
IE8 fails to load the slider, and the map, from examples/index.html. It looks like it's firing _updateKnob before the map has valid zoom levels. It's been really hard to figure out why. Checking for zoomLevels < Infinity before the knob updates fixes it for me.

Cheers,
Bryan
