### PR TITLE
L.Control.Zoomslider.js : update _onSliderClick() function

### DIFF
--- a/src/L.Control.Zoomslider.js
+++ b/src/L.Control.Zoomslider.js
@@ -133,8 +133,7 @@ L.Control.Zoomslider = (function () {
 
 		_onSliderClick: function (e) {
 			var first = (e.touches && e.touches.length === 1 ? e.touches[0] : e),
-				y = L.DomEvent.getMousePosition(first).y
-					- L.DomUtil.getViewportOffset(this._ui.body).y; // Cache this?
+				y = L.DomEvent.getMousePosition(first, this._ui.body).y;
 
 			this._knob.setPosition(y);
 			this._updateMapZoom();


### PR DESCRIPTION
The current code of `_onSliderClick()` function doesn't work with Leaflet 6.4 (because `getMousePosition()` needs a container as 2nd parameter).

My correction does the job with Leaflet 6.2 to 6.4 and 7.0-dev (master) !
