### PR TITLE
Make sure we are in Node land before to require leaflet.

### DIFF
--- a/src/L.Control.Zoomslider.js
+++ b/src/L.Control.Zoomslider.js
@@ -4,7 +4,7 @@
 	if (typeof define === 'function' && define.amd) {
 		// AMD
 		define(['leaflet'], factory);
-	} else if (typeof module !== 'undefined') {
+	} else if (typeof module !== 'undefined' && module && module.exports) {
 		// Node/CommonJS
 		L = require('leaflet');
 		module.exports = factory(L);


### PR DESCRIPTION
Hey guys, the test used before to check whether we are in Node Land is not enough and was generating some errors on our Angular tests.

Some libraries like angular-mock include 'module' in the window:
`window.module = angular.mock.module`

It is broadly safer to test whether the function we want to use in the following block (e.g `module.exports`) is indeed available.

Thanks guys!