### PR TITLE
Add fractional zoom levels support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
     "tests"
   ],
   "dependencies": {
-    "leaflet": "~0.7.1"
+    "leaflet": "1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	],
 	"description": "A zoom slider widget for Leaflet",
 	"dependencies": {
-		"leaflet": "~0.7.1"
+		"leaflet": "1.0.1"
 	},
 	"devDependencies": {
 		"mocha": "~1.9.0",

--- a/src/L.Control.Zoomslider.js
+++ b/src/L.Control.Zoomslider.js
@@ -160,21 +160,23 @@
 			},
 
 			_zoomIn: function (e) {
-				this._map.zoomIn(e.shiftKey ? 3 : 1);
+				var delta = this._map.options.zoomDelta || 0;
+				this._map.zoomIn(e.shiftKey ? 3 * delta : delta);
 			},
 			_zoomOut: function (e) {
-				this._map.zoomOut(e.shiftKey ? 3 : 1);
+				var delta = this._map.options.zoomDelta || 0;
+				this._map.zoomOut(e.shiftKey ? 3 * delta : delta);
 			},
 
 			_zoomLevels: function () {
-				var zoomLevels = this._map.getMaxZoom() - this._map.getMinZoom() + 1;
+				var zoomLevels = (this._map.getMaxZoom() - this._map.getMinZoom()) / this._map.options.zoomDelta + 1;
 				return zoomLevels < Infinity ? zoomLevels : 0;
 			},
 			_toZoomLevel: function (value) {
-				return value + this._map.getMinZoom();
+				return value * this._map.options.zoomDelta + this._map.getMinZoom();
 			},
 			_toValue: function (zoomLevel) {
-				return zoomLevel - this._map.getMinZoom();
+				return (zoomLevel - this._map.getMinZoom()) / this._map.options.zoomDelta;
 			},
 
 			_updateSize: function () {


### PR DESCRIPTION
Added fractional zoom levels, updated to leaflet 1.0.1
Supposed to be 0.8 version of plugin