### PR TITLE
Fix align with other leaflet controls

### DIFF
--- a/src/L.Control.Zoomslider.css
+++ b/src/L.Control.Zoomslider.css
@@ -99,10 +99,6 @@
 	font-size: 28px;
 	line-height: 30px;
 }
-.leaflet-touch .leaflet-control-zoomslider {
-	box-shadow: none;
-	border: 4px solid rgba(0,0,0,0.3);
-}
 
 /* Old IE */
 


### PR DESCRIPTION
Standard `.leaflet-control` border with is 2px, so we should not redefine it in our class in order to keep alignment of all controls.

Actually I am not aware of the initial purpose of this and others `.leaflet-touch` refinements in `L.Control.Zoomslider.css`.
Personally I get this class active even in desktop Chrome browser with no touchscreen on my PC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kartena/leaflet.zoomslider/74)
<!-- Reviewable:end -->
